### PR TITLE
[FIX] Submissions for members are missing

### DIFF
--- a/src/SubmissionEvaluationTest.Domain/SubmissionEvaluationTest.Domain.csproj
+++ b/src/SubmissionEvaluationTest.Domain/SubmissionEvaluationTest.Domain.csproj
@@ -1,25 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <ApplicationIcon />
-    <OutputType>Library</OutputType>
-    <StartupObject />
-  </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-      <PackageReference Include="NUnit" Version="3.13.2" />
-      <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-      <PackageReference Include="NSubstitute" Version="4.3.0" />
-  </ItemGroup>
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <ApplicationIcon/>
+        <OutputType>Library</OutputType>
+        <StartupObject/>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\SubmissionEvaluation.Domain\SubmissionEvaluation.Domain.csproj" />
-    <ProjectReference Include="..\SubmissionEvaluation.Providers.FileProvider\SubmissionEvaluation.Providers.FileProvider.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="FluentAssertions" Version="6.5.1"/>
+        <PackageReference Include="NUnit" Version="3.13.2"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0"/>
+        <PackageReference Include="NSubstitute" Version="4.3.0"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\SubmissionEvaluation.Domain\SubmissionEvaluation.Domain.csproj"/>
+        <ProjectReference Include="..\SubmissionEvaluation.Providers.FileProvider\SubmissionEvaluation.Providers.FileProvider.csproj"/>
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
# Issue
Fetching the submissions for a member or multiple members almost
never returns all the submissions and therefore all derived statistics
such as solved count, points, duplications score, ... are wrong.
Affected pages are:
* Account/Progress
* Members/Member/{id}
* Admin/Users for group admins

# Root cause
The BuildSubmitterRanklist uses Parallel.ForEach to process challenges
and their corresponding submissions in parallel but the implementation
is not thread-safe:
* Checking before inserting an entry into a ConcurrentDictionary
  Checking if a ConcurrentDictionary contains a Key and otherwise adding
  it is not thread-safe as another thread might have added the key after
  the check but before this thread is adding the key. Therefore
  submissions are added to different SubmitterRankings and only one is
  used to retrieve the submissions at the end.
* Modifying a non thread-safe collection (List<T>)
  System.ArgumentOutOfRangeException:
    capacity was less than the current size. (Parameter 'value')
    at System.Collections.Generic.List`1.AddWithResize(T item)
    at StatisticsOperations.cs:line 216

# Possible fixes
* Make the current implementation thread-safe
  Use AddOrUpdate helper method for the ConcurrentDictionary and add
  submissions in a thread-safe collection e. g. ConcurrentBag.
* Avoid an additional dictionary and collection by using LINQ AsParallel
* Process challenges and their submitters in serial

# Performance considerations
Deserializing all the files takes more than 4 seconds while grouping the
 submissions by submitter takes no more than 2 milliseconds regardless
 whether the grouping is parallelized or not. Therefore deserializing
 the files in parallel or asynchronous would have a much higher impact
 on the overall performance and should be considered.

The aforementioned run times are based on following file counts:
$ find _challenges -type f -name "challenge.md" | wc -l
287
$ find _submissions -type f -name "result.yml" | wc -l
11083

# Fix
Process the challenges and their corresponding submitters in serial.